### PR TITLE
refactor: removed `ForceConnect` and unused `Execute` pipeline

### DIFF
--- a/AwsWrapperDataProvider/Driver/Plugins/DefaultConnectionPlugin.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/DefaultConnectionPlugin.cs
@@ -43,15 +43,6 @@ public class DefaultConnectionPlugin(
         return methodFunc();
     }
 
-    public void Execute(
-        object methodInvokedOn,
-        string methodName,
-        ADONetDelegate methodFunc,
-        params object[] methodArgs)
-    {
-        methodFunc();
-    }
-
     public void OpenConnection(
         HostSpec? hostSpec,
         Dictionary<string, string> props,
@@ -68,22 +59,12 @@ public class DefaultConnectionPlugin(
         }
     }
 
-    public DbConnection ForceConnect(
-        HostSpec hostSpec,
-        Dictionary<string, string> props,
-        bool isInitialConnection,
-        ADONetDelegate<DbConnection> forceConnectmethodFunc)
-    {
-        throw new NotImplementedException();
-    }
-
     public void InitHostProvider(
         string initialUrl,
         Dictionary<string, string> props,
         IHostListProviderService hostListProviderService,
         ADONetDelegate<Action<object[]>> initHostProviderFunc)
     {
-        // TODO: stub implementation
-        return;
+        // do nothing
     }
 }

--- a/AwsWrapperDataProvider/Driver/Plugins/Efm/HostMonitoringPlugin.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/Efm/HostMonitoringPlugin.cs
@@ -34,16 +34,6 @@ public class HostMonitoringPlugin(IPluginService pluginService, Dictionary<strin
         throw new NotImplementedException();
     }
 
-    public void Execute(object methodInvokedOn, string methodName, ADONetDelegate methodFunc, params object[] methodArgs)
-    {
-        throw new NotImplementedException();
-    }
-
-    public DbConnection ForceConnect(HostSpec hostSpec, Dictionary<string, string> props, bool isInitialConnection, ADONetDelegate<DbConnection> forceConnectmethodFunc)
-    {
-        throw new NotImplementedException();
-    }
-
     public ISet<string> GetSubscribeMethods()
     {
         return SubscribeMethods;

--- a/AwsWrapperDataProvider/Driver/Plugins/Failover/FailoverPlugin.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/Failover/FailoverPlugin.cs
@@ -32,16 +32,6 @@ public class FailoverPlugin(IPluginService pluginService, Dictionary<string, str
         throw new NotImplementedException();
     }
 
-    public void Execute(object methodInvokedOn, string methodName, ADONetDelegate methodFunc, params object[] methodArgs)
-    {
-        throw new NotImplementedException();
-    }
-
-    public DbConnection ForceConnect(HostSpec hostSpec, Dictionary<string, string> props, bool isInitialConnection, ADONetDelegate<DbConnection> forceConnectmethodFunc)
-    {
-        throw new NotImplementedException();
-    }
-
     public ISet<string> GetSubscribeMethods()
     {
         throw new NotImplementedException();

--- a/AwsWrapperDataProvider/Driver/Plugins/IConnectionPlugin.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/IConnectionPlugin.cs
@@ -44,19 +44,6 @@ public interface IConnectionPlugin
         params object[] methodArgs);
 
     /// <summary>
-    /// Executes a void method with the given arguments.
-    /// </summary>
-    /// <param name="methodInvokedOn">The object the method is invoked on.</param>
-    /// <param name="methodName">The name of the method being invoked.</param>
-    /// <param name="methodFunc">The callable that executes the actual method.</param>
-    /// <param name="methodArgs">The arguments to pass to the method.</param>
-    void Execute(
-        object methodInvokedOn,
-        string methodName,
-        ADONetDelegate methodFunc,
-        params object[] methodArgs);
-
-    /// <summary>
     /// Opens a connection to the given host using the given properties.
     /// </summary>
     /// <param name="hostSpec">The host specification to connect to.</param>
@@ -68,20 +55,6 @@ public interface IConnectionPlugin
         Dictionary<string, string> props,
         bool isInitialConnection,
         ADONetDelegate methodFunc);
-
-    /// <summary>
-    /// Forces a connection to the given host using the given properties.
-    /// </summary>
-    /// <param name="hostSpec">The host specification to connect to.</param>
-    /// <param name="props">Connection properties.</param>
-    /// <param name="isInitialConnection">Whether this is the initial connection.</param>
-    /// <param name="forceConnectmethodFunc">The callable that executes the actual connection.</param>
-    /// <returns>The database connection.</returns>
-    DbConnection ForceConnect(
-        HostSpec hostSpec,
-        Dictionary<string, string> props,
-        bool isInitialConnection,
-        ADONetDelegate<DbConnection> forceConnectmethodFunc);
 
     /// <summary>
     /// Initializes the host provider.


### PR DESCRIPTION
### Summary

Removing unused pipelines.

### Description

- Removed `ForceConnect` pipeline - Removed similarly to why Connect was changed to OpenConnection pipeline. Not sure how to replace this yet, but will address when it is needed in failover.
- Removed unused void `Execute` pipeline since it is no longer needed as new ADONetDelegate can handled void cases.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
