### PR TITLE
feat: add support for MySql.Data.MySqlClient.MySqlConnection

### DIFF
--- a/AwsWrapperDataProvider.Tests/BasicConnectivityTests.cs
+++ b/AwsWrapperDataProvider.Tests/BasicConnectivityTests.cs
@@ -24,9 +24,38 @@ namespace AwsWrapperDataProvider.Tests
     {
         [Fact]
         [Trait("Category", "Integration")]
-        public void MysqlWrapperConnectionTest()
+        public void MySqlClientWrapperConnectionTest()
         {
-            const string connectionString = "Server=<insert_rds_instance_here>;User ID=admin;Password=my_password_2020;Initial Catalog=test;";
+            const string connectionString = "Server=127.0.0.1;User ID=root;Password=password;Initial Catalog=mysql;";
+            const string query = "select * from test";
+
+            using (AwsWrapperConnection<MySql.Data.MySqlClient.MySqlConnection> connection =
+                   new(connectionString))
+            {
+                AwsWrapperCommand<MySql.Data.MySqlClient.MySqlCommand> command = connection.CreateCommand<MySql.Data.MySqlClient.MySqlCommand>();
+                command.CommandText = query;
+
+                try
+                {
+                    connection.Open();
+                    IDataReader reader = command.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        Console.WriteLine(reader.GetInt32(0));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.ToString());
+                }
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void MySqlConnectorWrapperConnectionTest()
+        {
+            const string connectionString = "Server=localhost;Port=3306;User ID=root;Password=password;Initial Catalog=mysql;";
             const string query = "select @@aurora_server_id";
 
             using (AwsWrapperConnection<MySqlConnection> connection = new(connectionString))
@@ -56,7 +85,7 @@ namespace AwsWrapperDataProvider.Tests
                     IDataReader reader = command.ExecuteReader();
                     while (reader.Read())
                     {
-                        Console.WriteLine(reader.GetString(0));
+                        Console.WriteLine(reader.GetInt32(0));
                     }
                 }
                 catch (Exception ex)

--- a/AwsWrapperDataProvider.Tests/Driver/TargetConnectionDialects/TargetConnectionDialectProviderTests.cs
+++ b/AwsWrapperDataProvider.Tests/Driver/TargetConnectionDialects/TargetConnectionDialectProviderTests.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using AwsWrapperDataProvider.Driver.Dialects;
+using AwsWrapperDataProvider.Driver.HostInfo;
 using AwsWrapperDataProvider.Driver.TargetConnectionDialects;
 using AwsWrapperDataProvider.Driver.Utils;
 using MySqlConnector;
@@ -23,8 +25,8 @@ public class TargetConnectionDialectProviderTests
 {
     [Theory]
     [Trait("Category", "Unit")]
-    [InlineData(typeof(NpgsqlConnection), typeof(PgTargetConnectionDialect))]
-    [InlineData(typeof(MySqlConnection), typeof(MySqlTargetConnectionDialect))]
+    [InlineData(typeof(NpgsqlConnection), typeof(NpgsqlDialect))]
+    [InlineData(typeof(MySqlConnection), typeof(MySqlConnectorDialect))]
     public void GetDialect_WithSupportedConnectionType_ReturnsTargetDriverDialect(Type connectionType, Type dialectType)
     {
         var dialect = TargetConnectionDialectProvider.GetDialect(connectionType, null);
@@ -95,7 +97,7 @@ public class TargetConnectionDialectProviderTests
         var props = new Dictionary<string, string>();
         var dialect = TargetConnectionDialectProvider.GetDialect(typeof(NpgsqlConnection), props);
         Assert.NotNull(dialect);
-        Assert.IsType<PgTargetConnectionDialect>(dialect);
+        Assert.IsType<NpgsqlDialect>(dialect);
     }
 
     // Test custom dialect implementation
@@ -107,7 +109,7 @@ public class TargetConnectionDialectProviderTests
 
         public ISet<string> GetAllowedOnConnectionMethodNames() => new HashSet<string>();
 
-        public string PrepareConnectionString(AwsWrapperDataProvider.Driver.HostInfo.HostSpec? hostSpec, Dictionary<string, string> props)
+        public string PrepareConnectionString(IDialect dialect, HostSpec? hostSpec, Dictionary<string, string> props)
         {
             return "TestConnectionString";
         }

--- a/AwsWrapperDataProvider.Tests/Driver/TargetConnectionDialects/TargetConnectionDialectTests.cs
+++ b/AwsWrapperDataProvider.Tests/Driver/TargetConnectionDialects/TargetConnectionDialectTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using AwsWrapperDataProvider.Driver.Dialects;
 using AwsWrapperDataProvider.Driver.HostInfo;
 using AwsWrapperDataProvider.Driver.TargetConnectionDialects;
 using AwsWrapperDataProvider.Driver.Utils;
@@ -71,8 +72,9 @@ public class TargetConnectionDialectTests
     [Trait("Category", "Unit")]
     public void PgTargetDriverDialect_PrepareConnectionString_WithHostSpec_IncludesHostAndPort()
     {
-        var dialect = new PgTargetConnectionDialect();
-        var connectionString = dialect.PrepareConnectionString(HostWithPort, ConnectionProps);
+        var connectionDialect = new NpgsqlDialect();
+        var dialect = new PgDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, HostWithPort, ConnectionProps);
 
         Assert.Contains("Host=test-host", connectionString);
         Assert.Contains("Port=5432", connectionString);
@@ -85,8 +87,9 @@ public class TargetConnectionDialectTests
     [Trait("Category", "Unit")]
     public void PgTargetDriverDialect_PrepareConnectionString_WithoutPort_OmitsPortParameter()
     {
-        var dialect = new PgTargetConnectionDialect();
-        var connectionString = dialect.PrepareConnectionString(HostWithoutPort, BasicDatabaseProps);
+        var connectionDialect = new NpgsqlDialect();
+        var dialect = new PgDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, HostWithoutPort, BasicDatabaseProps);
 
         Assert.Contains("Host=test-host", connectionString);
         Assert.DoesNotContain("Port=", connectionString);
@@ -96,8 +99,9 @@ public class TargetConnectionDialectTests
     [Trait("Category", "Unit")]
     public void PgTargetDriverDialect_PrepareConnectionString_WithoutHostSpec_UsesPropertiesOnly()
     {
-        var dialect = new PgTargetConnectionDialect();
-        var connectionString = dialect.PrepareConnectionString(null, PropertiesWithHost);
+        var connectionDialect = new NpgsqlDialect();
+        var dialect = new PgDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, null, PropertiesWithHost);
 
         Assert.Contains("Host=original-host", connectionString);
         Assert.Contains("Port=5432", connectionString);
@@ -108,8 +112,9 @@ public class TargetConnectionDialectTests
     [Trait("Category", "Unit")]
     public void PgTargetDriverDialect_PrepareConnectionString_FiltersInternalProperties()
     {
-        var dialect = new PgTargetConnectionDialect();
-        var connectionString = dialect.PrepareConnectionString(HostWithPort, PropsWithInternalProperties);
+        var connectionDialect = new NpgsqlDialect();
+        var dialect = new PgDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, HostWithPort, PropsWithInternalProperties);
 
         Assert.Contains("Host=test-host", connectionString);
         Assert.Contains("Port=5432", connectionString);
@@ -122,8 +127,9 @@ public class TargetConnectionDialectTests
     [Trait("Category", "Unit")]
     public void MySqlTargetDriverDialect_PrepareConnectionString_WithHostSpec_IncludesServerAndPort()
     {
-        var dialect = new MySqlTargetConnectionDialect();
-        var connectionString = dialect.PrepareConnectionString(HostWithPort, ConnectionProps);
+        var connectionDialect = new MySqlConnectorDialect();
+        var dialect = new MysqlDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, HostWithPort, ConnectionProps);
 
         Assert.Contains("Server=test-host", connectionString);
         Assert.Contains("Port=5432", connectionString);
@@ -136,19 +142,21 @@ public class TargetConnectionDialectTests
     [Trait("Category", "Unit")]
     public void MySqlTargetDriverDialect_PrepareConnectionString_WithoutPort_OmitsPortParameter()
     {
-        var dialect = new MySqlTargetConnectionDialect();
-        var connectionString = dialect.PrepareConnectionString(HostWithoutPort, BasicDatabaseProps);
+        var connectionDialect = new MySqlConnectorDialect();
+        var dialect = new MysqlDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, HostWithoutPort, BasicDatabaseProps);
 
         Assert.Contains("Server=test-host", connectionString);
-        Assert.DoesNotContain("Port=", connectionString);
+        Assert.Contains("Port=3306", connectionString);
     }
 
     [Fact]
     [Trait("Category", "Unit")]
     public void MySqlTargetDriverDialect_PrepareConnectionString_WithoutHostSpec_UsesPropertiesOnly()
     {
-        var dialect = new MySqlTargetConnectionDialect();
-        var connectionString = dialect.PrepareConnectionString(null, PropertiesWithServer);
+        var connectionDialect = new MySqlConnectorDialect();
+        var dialect = new MysqlDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, null, PropertiesWithServer);
 
         Assert.Contains("Server=original-host", connectionString);
         Assert.Contains("Port=5432", connectionString);
@@ -159,8 +167,64 @@ public class TargetConnectionDialectTests
     [Trait("Category", "Unit")]
     public void MySqlTargetDriverDialect_PrepareConnectionString_FiltersInternalProperties()
     {
-        var dialect = new MySqlTargetConnectionDialect();
-        var connectionString = dialect.PrepareConnectionString(HostWithPort, PropsWithInternalProperties);
+        var connectionDialect = new MySqlConnectorDialect();
+        var dialect = new MysqlDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, HostWithPort, PropsWithInternalProperties);
+
+        Assert.Contains("Server=test-host", connectionString);
+        Assert.Contains("Port=5432", connectionString);
+        Assert.Contains("Database=testdb", connectionString);
+        Assert.DoesNotContain(PropertyDefinition.TargetConnectionType.Name, connectionString);
+        Assert.DoesNotContain(PropertyDefinition.CustomTargetConnectionDialect.Name, connectionString);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void MySqlClientDialect_PrepareConnectionString_WithHostSpec_IncludesServerAndPort()
+    {
+        var connectionDialect = new MySqlClientDialect();
+        var dialect = new MysqlDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, HostWithPort, ConnectionProps);
+
+        Assert.Contains("Server=test-host", connectionString);
+        Assert.Contains("Port=5432", connectionString);
+        Assert.Contains("Database=testdb", connectionString);
+        Assert.Contains("Username=testuser", connectionString);
+        Assert.Contains("Password=testpass", connectionString);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void MySqlClientDialect_PrepareConnectionString_WithoutPort_OmitsPortParameter()
+    {
+        var connectionDialect = new MySqlClientDialect();
+        var dialect = new MysqlDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, HostWithoutPort, BasicDatabaseProps);
+
+        Assert.Contains("Server=test-host", connectionString);
+        Assert.Contains("Port=3306", connectionString);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void MySqlClientDialect_PrepareConnectionString_WithoutHostSpec_UsesPropertiesOnly()
+    {
+        var connectionDialect = new MySqlClientDialect();
+        var dialect = new MysqlDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, null, PropertiesWithServer);
+
+        Assert.Contains("Server=original-host", connectionString);
+        Assert.Contains("Port=5432", connectionString);
+        Assert.Contains("Database=testdb", connectionString);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void MySqlClientDialect_PrepareConnectionString_FiltersInternalProperties()
+    {
+        var connectionDialect = new MySqlClientDialect();
+        var dialect = new MysqlDialect();
+        var connectionString = connectionDialect.PrepareConnectionString(dialect, HostWithPort, PropsWithInternalProperties);
 
         Assert.Contains("Server=test-host", connectionString);
         Assert.Contains("Port=5432", connectionString);

--- a/AwsWrapperDataProvider/Driver/ConnectionProviders/DbConnectionProvider.cs
+++ b/AwsWrapperDataProvider/Driver/ConnectionProviders/DbConnectionProvider.cs
@@ -38,7 +38,7 @@ public class DbConnectionProvider() : IConnectionProvider
         Dictionary<string, string> props)
     {
         Type targetConnectionType = targetConnectionDialect.DriverConnectionType;
-        string connectionString = targetConnectionDialect.PrepareConnectionString(hostSpec, props);
+        string connectionString = targetConnectionDialect.PrepareConnectionString(dialect, hostSpec, props);
 
         DbConnection? targetConnection = string.IsNullOrWhiteSpace(connectionString)
             ? (DbConnection?)Activator.CreateInstance(targetConnectionType)

--- a/AwsWrapperDataProvider/Driver/Dialects/MysqlDialect.cs
+++ b/AwsWrapperDataProvider/Driver/Dialects/MysqlDialect.cs
@@ -16,6 +16,7 @@ using System.Data;
 using System.Data.Common;
 using AwsWrapperDataProvider.Driver.HostInfo;
 using AwsWrapperDataProvider.Driver.HostListProviders;
+using AwsWrapperDataProvider.Driver.Utils;
 
 namespace AwsWrapperDataProvider.Driver.Dialects;
 
@@ -68,6 +69,11 @@ public class MysqlDialect : IDialect
 
     public virtual void PrepareConnectionProperties(Dictionary<string, string> props, HostSpec hostSpec)
     {
-        // Do nothing.
+        // If PORT is not set, assign to default port.
+        int? port = PropertyDefinition.Port.GetInt(props);
+        if (port is null)
+        {
+            PropertyDefinition.Port.Set(props, this.DefaultPort.ToString());
+        }
     }
 }

--- a/AwsWrapperDataProvider/Driver/TargetConnectionDialects/GenericTargetConnectionDialect.cs
+++ b/AwsWrapperDataProvider/Driver/TargetConnectionDialects/GenericTargetConnectionDialect.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Data.Common;
+using AwsWrapperDataProvider.Driver.Dialects;
 using AwsWrapperDataProvider.Driver.HostInfo;
 using AwsWrapperDataProvider.Driver.Utils;
 
@@ -27,14 +28,14 @@ public abstract class GenericTargetConnectionDialect : ITargetConnectionDialect
         return connectionType == this.DriverConnectionType;
     }
 
-    public abstract string PrepareConnectionString(HostSpec? hostSpec, Dictionary<string, string> props);
+    public abstract string PrepareConnectionString(IDialect dialect, HostSpec? hostSpec, Dictionary<string, string> props);
 
     public ISet<string> GetAllowedOnConnectionMethodNames()
     {
         throw new NotImplementedException("Will implement in Milestone 5, as feature is only relevant to Failover.");
     }
 
-    protected string PrepareConnectionString(HostSpec? hostSpec, Dictionary<string, string> props, AwsWrapperProperty hostProperty)
+    protected string PrepareConnectionString(IDialect dialect, HostSpec? hostSpec, Dictionary<string, string> props, AwsWrapperProperty hostProperty)
     {
         Dictionary<string, string> targetConnectionParameters = props.Where(x =>
             !PropertyDefinition.InternalWrapperProperties
@@ -43,6 +44,7 @@ public abstract class GenericTargetConnectionDialect : ITargetConnectionDialect
 
         if (hostSpec != null)
         {
+            dialect.PrepareConnectionProperties(targetConnectionParameters, hostSpec);
             hostProperty.Set(targetConnectionParameters, hostSpec.Host);
             if (hostSpec.IsPortSpecified)
             {

--- a/AwsWrapperDataProvider/Driver/TargetConnectionDialects/ITargetConnectionDialect.cs
+++ b/AwsWrapperDataProvider/Driver/TargetConnectionDialects/ITargetConnectionDialect.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Data.Common;
+using AwsWrapperDataProvider.Driver.Dialects;
 using AwsWrapperDataProvider.Driver.HostInfo;
 using AwsWrapperDataProvider.Driver.Utils;
 
@@ -38,10 +39,11 @@ public interface ITargetConnectionDialect
     /// <summary>
     /// Prepares a connection string for the given host specification and properties.
     /// </summary>
+    /// <param name="dialect">The dialect of connection.</param>
     /// <param name="hostSpec">The host specification.</param>
     /// <param name="props">Connection properties.</param>
     /// <returns>The prepared connection string.</returns>
-    string PrepareConnectionString(HostSpec? hostSpec, Dictionary<string, string> props);
+    string PrepareConnectionString(IDialect dialect, HostSpec? hostSpec, Dictionary<string, string> props);
 
     /// <summary>
     /// Gets the set of method names that are allowed to be called on the connection.

--- a/AwsWrapperDataProvider/Driver/TargetConnectionDialects/MySqlClientDialect.cs
+++ b/AwsWrapperDataProvider/Driver/TargetConnectionDialects/MySqlClientDialect.cs
@@ -12,20 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using AwsWrapperDataProvider.Driver.Dialects;
 using AwsWrapperDataProvider.Driver.HostInfo;
 using AwsWrapperDataProvider.Driver.Utils;
-using Npgsql;
+using MySql.Data.MySqlClient;
 
 namespace AwsWrapperDataProvider.Driver.TargetConnectionDialects;
 
-public class PgTargetConnectionDialect : GenericTargetConnectionDialect
+public class MySqlClientDialect : GenericTargetConnectionDialect
 {
-    public override Type DriverConnectionType { get; } = typeof(NpgsqlConnection);
-
-    public override string PrepareConnectionString(
-        HostSpec? hostSpec,
-        Dictionary<string, string> props)
+    public override Type DriverConnectionType { get; } = typeof(MySqlConnection);
+    public override string PrepareConnectionString(IDialect dialect, HostSpec? hostSpec, Dictionary<string, string> props)
     {
-        return this.PrepareConnectionString(hostSpec, props, PropertyDefinition.Host);
+        return this.PrepareConnectionString(dialect, hostSpec, props, PropertyDefinition.Server);
     }
 }

--- a/AwsWrapperDataProvider/Driver/TargetConnectionDialects/MySqlConnectorDialect.cs
+++ b/AwsWrapperDataProvider/Driver/TargetConnectionDialects/MySqlConnectorDialect.cs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using AwsWrapperDataProvider.Driver.Dialects;
+using AwsWrapperDataProvider.Driver.HostInfo;
+using AwsWrapperDataProvider.Driver.Utils;
+using MySqlConnector;
+
+namespace AwsWrapperDataProvider.Driver.TargetConnectionDialects;
+
+public class MySqlConnectorDialect : GenericTargetConnectionDialect
+{
+    public override Type DriverConnectionType { get; } = typeof(MySqlConnection);
+
+    public override string PrepareConnectionString(
+        IDialect dialect,
+        HostSpec? hostSpec,
+        Dictionary<string, string> props)
+    {
+        PropertyDefinition.Port.GetInt(props);
+        return this.PrepareConnectionString(dialect, hostSpec, props, PropertyDefinition.Server);
+    }
+}

--- a/AwsWrapperDataProvider/Driver/TargetConnectionDialects/NpgsqlDialect.cs
+++ b/AwsWrapperDataProvider/Driver/TargetConnectionDialects/NpgsqlDialect.cs
@@ -12,21 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Data.Common;
+using AwsWrapperDataProvider.Driver.Dialects;
 using AwsWrapperDataProvider.Driver.HostInfo;
 using AwsWrapperDataProvider.Driver.Utils;
-using MySqlConnector;
+using Npgsql;
 
 namespace AwsWrapperDataProvider.Driver.TargetConnectionDialects;
 
-public class MySqlTargetConnectionDialect : GenericTargetConnectionDialect
+public class NpgsqlDialect : GenericTargetConnectionDialect
 {
-    public override Type DriverConnectionType { get; } = typeof(MySqlConnection);
+    public override Type DriverConnectionType { get; } = typeof(NpgsqlConnection);
 
     public override string PrepareConnectionString(
+        IDialect dialect,
         HostSpec? hostSpec,
         Dictionary<string, string> props)
     {
-        return this.PrepareConnectionString(hostSpec, props, PropertyDefinition.Server);
+        return this.PrepareConnectionString(dialect, hostSpec, props, PropertyDefinition.Host);
     }
 }

--- a/AwsWrapperDataProvider/Driver/TargetConnectionDialects/TargetConnectionDialectProvider.cs
+++ b/AwsWrapperDataProvider/Driver/TargetConnectionDialects/TargetConnectionDialectProvider.cs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 using AwsWrapperDataProvider.Driver.Utils;
-using MySqlConnector;
-using Npgsql;
 
 namespace AwsWrapperDataProvider.Driver.TargetConnectionDialects;
 
@@ -22,8 +20,9 @@ public static class TargetConnectionDialectProvider
 {
     private static readonly Dictionary<Type, Type> ConnectionToDialectMap = new()
     {
-        { typeof(NpgsqlConnection), typeof(PgTargetConnectionDialect) },
-        { typeof(MySqlConnection), typeof(MySqlTargetConnectionDialect) },
+        { typeof(Npgsql.NpgsqlConnection), typeof(NpgsqlDialect) },
+        { typeof(MySqlConnector.MySqlConnection), typeof(MySqlConnectorDialect) },
+        { typeof(MySql.Data.MySqlClient.MySqlConnection), typeof(MySqlClientDialect) },
     };
 
     public static ITargetConnectionDialect GetDialect(Type connectionType, Dictionary<string, string>? props)


### PR DESCRIPTION
### Summary
 
add support for MySql.Data.MySqlClient.MySqlConnection

### Description

- added `MySqlClientDialect`.
- renamed other TargetConnectionDialects to represent the library they are part of.
- changed `ITargetConnectionDialect. PrepareConnectionString(...)` to take `IDialect` and use `IDialect.PrepareConnectionProperties`
  - added because if MySql connection uses IP server with out Port set, connection will timeout when tried to be open. Now will add port if not set.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
