### PR TITLE
fix: retry auth plugins only on login exception + is cached token

### DIFF
--- a/AwsWrapperDataProvider/Driver/Plugins/FederatedAuth/FederatedAuthPlugin.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/FederatedAuth/FederatedAuthPlugin.cs
@@ -82,15 +82,13 @@ public partial class FederatedAuthPlugin(IPluginService pluginService, Dictionar
         }
         catch (Exception ex)
         {
-            // should the token not work (expired on the server), generate a new one and try again
-            if (isCachedToken)
+            if (!this.pluginService.IsLoginException(ex) || !isCachedToken)
             {
-                this.UpdateAuthenticationToken(hostSpec, props, host, port, region, cacheKey, dbUser);
+                throw;
             }
-            else
-            {
-                throw new Exception("Failed to connect; token generation may be at fault.", ex);
-            }
+
+            // should the token not work (login exception + is cached token), generate a new one and try again
+            this.UpdateAuthenticationToken(hostSpec, props, host, port, region, cacheKey, dbUser);
 
             methodFunc();
         }

--- a/AwsWrapperDataProvider/Driver/Plugins/SecretsManager/SecretsManagerAuthPlugin.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/SecretsManager/SecretsManagerAuthPlugin.cs
@@ -62,17 +62,15 @@ public class SecretsManagerAuthPlugin(IPluginService pluginService, Dictionary<s
         }
         catch (Exception ex)
         {
-            if (!this.pluginService.IsLoginException(ex))
+            if (!this.pluginService.IsLoginException(ex) || secretsWasFetched)
             {
                 throw;
             }
 
-            if (!secretsWasFetched)
-            {
-                this.UpdateSecrets(true);
-                this.ApplySecretToProperties(props);
-                methodFunc();
-            }
+            // should the token not work (login exception + is cached token), generate a new one and try again
+            this.UpdateSecrets(true);
+            this.ApplySecretToProperties(props);
+            methodFunc();
         }
     }
 


### PR DESCRIPTION
### Summary

Updates IAM and Secrets Manager authentication plugins to retry only if the caught exception is a login error.

### Description

If the exception is not a login exception, re-throw exception.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
