### PR TITLE
fix: ExecuteInstanceIdQuery return value changed to nullable type

### DIFF
--- a/AwsWrapperDataProvider.Tests/Container/Utils/AuroraTestUtils.cs
+++ b/AwsWrapperDataProvider.Tests/Container/Utils/AuroraTestUtils.cs
@@ -810,7 +810,7 @@ public class AuroraTestUtils
         return result;
     }
 
-    public string ExecuteInstanceIdQuery(IDbConnection connection, DatabaseEngine engine, DatabaseEngineDeployment deployment)
+    public string? ExecuteInstanceIdQuery(IDbConnection connection, DatabaseEngine engine, DatabaseEngineDeployment deployment)
     {
         string instanceId;
         try


### PR DESCRIPTION
### Summary

Warning when building since return value is not nullable but returns a null value.

### Description

ExecuteInstanceIdQuery return value changed to nullable.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
