### PR TITLE
fix: allow passing duplicate parameters in connection string

### DIFF
--- a/AwsWrapperDataProvider.Tests/Driver/Utils/ConnectionPropertiesUtilsTests.cs
+++ b/AwsWrapperDataProvider.Tests/Driver/Utils/ConnectionPropertiesUtilsTests.cs
@@ -24,6 +24,7 @@ public class ConnectionPropertiesUtilsTests
     [InlineData("host=myhost.example.com;port=5432;database=mydb;username=myuser;password=mypassword", 5)]
     [InlineData("Host=myhost.example.com;Port=5432", 2)]
     [InlineData("Host=myhost.example.com", 1)]
+    [InlineData("Host=NOT-myhost.example.com;Host=myhost.example.com", 1)]
     public void ParseConnectionStringParameters_WithValidConnectionString_ReturnsDictionary(string connectionString, int expectedCount)
     {
         var result = ConnectionPropertiesUtils.ParseConnectionStringParameters(connectionString);

--- a/AwsWrapperDataProvider/Driver/Utils/ConnectionPropertiesUtils.cs
+++ b/AwsWrapperDataProvider/Driver/Utils/ConnectionPropertiesUtils.cs
@@ -36,7 +36,8 @@ public static class ConnectionPropertiesUtils
             .Split(";", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
             .Select(x => x.Split("=", StringSplitOptions.TrimEntries))
             .Where(pairs => pairs.Length == 2 && !string.IsNullOrEmpty(pairs[0]))
-            .ToDictionary(pairs => pairs[0], pairs => pairs[1], StringComparer.OrdinalIgnoreCase);
+            .GroupBy(pairs => pairs[0], StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.Last()[1], StringComparer.OrdinalIgnoreCase);
 
         // Check and warn about SSL insecure configuration
         if (PropertyDefinition.SslInsecure.GetBoolean(props))


### PR DESCRIPTION
### Summary

Allow passing duplicate parameters in connection string

### Description

Filter out all duplicate parameters and keep the second instance.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
