### PR TITLE
fix: unable to set monitoring parameters

### DIFF
--- a/AwsWrapperDataProvider.Tests/EfmConnectivityTests.cs
+++ b/AwsWrapperDataProvider.Tests/EfmConnectivityTests.cs
@@ -63,6 +63,25 @@ public class EfmConnectivityTests
         await PerformEfmTest(connectionString, clusterEndpoint, failureDetectionTime, failureDetectionInterval, failureDetectionCount);
     }
 
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Category", "Manual")]
+    public async Task EfmPluginTest_WithMonitoringProperty()
+    {
+        const string clusterEndpoint = "endpoint"; // Replace with your cluster endpoint
+        const string user = "username"; // Replace with the name of the db user to connect with
+        const string password = "password"; // Replace with password of the db user to connect with
+        const string database = "database"; // Replace with your database name
+
+        int failureDetectionTime = 1000; // start monitoring after one second
+        int failureDetectionInterval = 1000; // check on the connection every 1 second
+        int failureDetectionCount = 1; // five failures before considered unhealthy
+
+        var connectionString = $"Host={clusterEndpoint};Username={user};Password={password};Database={database};";
+        connectionString += $"; Plugins=efm;FailureDetectionTime={failureDetectionTime};FailureDetectionInterval={failureDetectionInterval};FailureDetectionCount={failureDetectionCount};monitoring-connecttimeout=50";
+        await PerformEfmTest(connectionString, clusterEndpoint, failureDetectionTime, failureDetectionInterval, failureDetectionCount);
+    }
+
     internal static async Task PerformEfmTest(string connectionString, string initialHost, int failureDetectionTime, int failureDetectionInterval, int failureDetectionCount)
     {
         try

--- a/AwsWrapperDataProvider/Driver/Plugins/Efm/HostMonitor.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/Efm/HostMonitor.cs
@@ -26,7 +26,6 @@ public class HostMonitor : IHostMonitor
 {
     private static readonly ILogger<HostMonitor> Logger = LoggerUtils.GetLogger<HostMonitor>();
     private static readonly int ThreadSleepMs = 100;
-    private static readonly string MonitoringPropertyPrefix = "monitoring-";
 
     private readonly ConcurrentQueue<WeakReference<HostMonitorConnectionContext>> activeContexts = new();
     private readonly MemoryCache newContexts = new(new MemoryCacheOptions());
@@ -312,9 +311,9 @@ public class HostMonitor : IHostMonitor
 
                 foreach (string key in this.properties.Keys)
                 {
-                    if (key.StartsWith(MonitoringPropertyPrefix))
+                    if (key.StartsWith(PropertyDefinition.MonitoringPropertyPrefix))
                     {
-                        monitoringConnProperties[key[MonitoringPropertyPrefix.Length..]] = this.properties[key];
+                        monitoringConnProperties[key[PropertyDefinition.MonitoringPropertyPrefix.Length..]] = this.properties[key];
                         monitoringConnProperties.Remove(key);
                     }
                 }

--- a/AwsWrapperDataProvider/Driver/TargetConnectionDialects/GenericTargetConnectionDialect.cs
+++ b/AwsWrapperDataProvider/Driver/TargetConnectionDialects/GenericTargetConnectionDialect.cs
@@ -40,7 +40,9 @@ public abstract class GenericTargetConnectionDialect : ITargetConnectionDialect
         Dictionary<string, string> targetConnectionParameters = props.Where(x =>
             !PropertyDefinition.InternalWrapperProperties
                 .Select(prop => prop.Name)
-                .Contains(x.Key)).ToDictionary();
+                .Contains(x.Key) &&
+                !x.Key.StartsWith(PropertyDefinition.MonitoringPropertyPrefix, StringComparison.OrdinalIgnoreCase))
+                .ToDictionary();
 
         if (hostSpec != null)
         {

--- a/AwsWrapperDataProvider/Driver/Utils/PropertyDefinition.cs
+++ b/AwsWrapperDataProvider/Driver/Utils/PropertyDefinition.cs
@@ -263,6 +263,9 @@ public static class PropertyDefinition
         FailureDetectionCount,
     ];
 
+    // EFM specific monitoring property, not related to cluster monitoring
+    public static readonly string MonitoringPropertyPrefix = "monitoring-";
+
     public static string GetConnectionUrl(Dictionary<string, string> props)
     {
         return Server.GetString(props) ?? Host.GetString(props) ?? throw new ArgumentException("Connection url is missing.");


### PR DESCRIPTION
### Summary

Monitoring parameters causing exception

### Description

The monitoring parameters are being passed through as the connection string but throwing exception because these parameters are not being filtered or allowed in the dialects. Need to filter them out before passing the properties to create the connection string.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
