### PR TITLE
fix: plugins codes for mysql handling efm

### DIFF
--- a/AwsWrapperDataProvider.Dialect.MySqlClient/MySqlClientDialect.cs
+++ b/AwsWrapperDataProvider.Dialect.MySqlClient/MySqlClientDialect.cs
@@ -14,6 +14,7 @@
 
 using AwsWrapperDataProvider.Driver.Dialects;
 using AwsWrapperDataProvider.Driver.HostInfo;
+using AwsWrapperDataProvider.Driver.Plugins;
 using AwsWrapperDataProvider.Driver.TargetConnectionDialects;
 using AwsWrapperDataProvider.Driver.Utils;
 using MySql.Data.MySqlClient;
@@ -22,9 +23,18 @@ namespace AwsWrapperDataProvider.Dialect.MySqlClient;
 
 public class MySqlClientDialect : AbstractTargetConnectionDialect
 {
+    private const string DefaultPluginCode = "initialConnection, failover";
+
     public override Type DriverConnectionType { get; } = typeof(MySqlConnection);
+
     public override string PrepareConnectionString(IDialect dialect, HostSpec? hostSpec, Dictionary<string, string> props)
     {
         return this.PrepareConnectionString(dialect, hostSpec, props, PropertyDefinition.Server);
+    }
+
+    public override string GetPluginCodesOrDefault(Dictionary<string, string> props)
+    {
+        string pluginsCodes = PropertyDefinition.Plugins.GetString(props) ?? DefaultPluginCode;
+        return pluginsCodes.Contains(PluginCodes.HostMonitoring) ? throw new InvalidOperationException("Invalid usage of Host Monitoring plugin with Mysql dialect.") : pluginsCodes;
     }
 }

--- a/AwsWrapperDataProvider.Dialect.MySqlConnector/MySqlConnectorDialect.cs
+++ b/AwsWrapperDataProvider.Dialect.MySqlConnector/MySqlConnectorDialect.cs
@@ -14,6 +14,7 @@
 
 using AwsWrapperDataProvider.Driver.Dialects;
 using AwsWrapperDataProvider.Driver.HostInfo;
+using AwsWrapperDataProvider.Driver.Plugins;
 using AwsWrapperDataProvider.Driver.TargetConnectionDialects;
 using AwsWrapperDataProvider.Driver.Utils;
 using MySqlConnector;
@@ -22,6 +23,8 @@ namespace AwsWrapperDataProvider.Dialect.MySqlConnector;
 
 public class MySqlConnectorDialect : AbstractTargetConnectionDialect
 {
+    private const string DefaultPluginCode = "initialConnection, failover";
+
     public override Type DriverConnectionType { get; } = typeof(MySqlConnection);
 
     public override string PrepareConnectionString(
@@ -31,5 +34,11 @@ public class MySqlConnectorDialect : AbstractTargetConnectionDialect
     {
         PropertyDefinition.Port.GetInt(props);
         return this.PrepareConnectionString(dialect, hostSpec, props, PropertyDefinition.Server);
+    }
+
+    public override string GetPluginCodesOrDefault(Dictionary<string, string> props)
+    {
+        string pluginsCodes = PropertyDefinition.Plugins.GetString(props) ?? DefaultPluginCode;
+        return pluginsCodes.Contains(PluginCodes.HostMonitoring) ? throw new InvalidOperationException("Invalid usage of Host Monitoring plugin with Mysql dialect.") : pluginsCodes;
     }
 }

--- a/AwsWrapperDataProvider.Tests/Driver/ConnectionPluginManagerTests.cs
+++ b/AwsWrapperDataProvider.Tests/Driver/ConnectionPluginManagerTests.cs
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 using System.Data.Common;
+using AwsWrapperDataProvider.Dialect.MySqlClient;
 using AwsWrapperDataProvider.Driver;
 using AwsWrapperDataProvider.Driver.ConnectionProviders;
+using AwsWrapperDataProvider.Driver.Dialects;
 using AwsWrapperDataProvider.Driver.HostInfo;
 using AwsWrapperDataProvider.Driver.Plugins;
+using AwsWrapperDataProvider.Driver.TargetConnectionDialects;
 using AwsWrapperDataProvider.Driver.Utils;
 using AwsWrapperDataProvider.Tests.Driver.Plugins;
 using Moq;
@@ -235,8 +238,11 @@ public class ConnectionPluginManagerTests
             this.mockWrapperConnection,
             null);
 
+        Mock<IPluginService> pluginServiceMock = new();
+        pluginServiceMock.Setup(ps => ps.TargetConnectionDialect).Returns(new MySqlClientDialect());
+
         pluginManager.InitConnectionPluginChain(
-            Mock.Of<IPluginService>(),
+            pluginServiceMock.Object,
             props);
 
         IList<IConnectionPlugin> plugins = TestUtils.GetNonPublicInstanceField<IList<IConnectionPlugin>>(pluginManager, "plugins")!;

--- a/AwsWrapperDataProvider.Tests/Driver/TargetConnectionDialects/TargetConnectionDialectProviderTests.cs
+++ b/AwsWrapperDataProvider.Tests/Driver/TargetConnectionDialects/TargetConnectionDialectProviderTests.cs
@@ -114,6 +114,11 @@ public class TargetConnectionDialectProviderTests
 
         public ISet<string> GetAllowedOnConnectionMethodNames() => new HashSet<string>();
 
+        public string GetPluginCodesOrDefault(Dictionary<string, string> props)
+        {
+            return "efm,failover";
+        }
+
         public string PrepareConnectionString(IDialect dialect, HostSpec? hostSpec, Dictionary<string, string> props)
         {
             return "TestConnectionString";

--- a/AwsWrapperDataProvider/Driver/Plugins/ConnectionPluginChainBuilder.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/ConnectionPluginChainBuilder.cs
@@ -27,7 +27,6 @@ namespace AwsWrapperDataProvider.Driver.Plugins;
 public class ConnectionPluginChainBuilder
 {
     private const int WeightRelativeToPriorPlugin = -1;
-    private const string DefaultPluginCode = "efm,failover";
 
     private static readonly ILogger<ConnectionPluginChainBuilder> Logger = LoggerUtils.GetLogger<ConnectionPluginChainBuilder>();
 
@@ -70,7 +69,7 @@ public class ConnectionPluginChainBuilder
         }
         else
         {
-            string pluginsCodes = PropertyDefinition.Plugins.GetString(props) ?? DefaultPluginCode;
+            string pluginsCodes = pluginService.TargetConnectionDialect.GetPluginCodesOrDefault(props);
             string[] pluginsCodesArray = [.. pluginsCodes.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)];
             Logger.LogDebug("Current Plugins: " + string.Join(",", pluginsCodesArray));
 

--- a/AwsWrapperDataProvider/Driver/TargetConnectionDialects/AbstractTargetConnectionDialect.cs
+++ b/AwsWrapperDataProvider/Driver/TargetConnectionDialects/AbstractTargetConnectionDialect.cs
@@ -21,6 +21,8 @@ namespace AwsWrapperDataProvider.Driver.TargetConnectionDialects;
 
 public abstract class AbstractTargetConnectionDialect : ITargetConnectionDialect
 {
+    private const string DefaultPluginCode = "initialConnection, efm,failover";
+
     public abstract Type DriverConnectionType { get; }
 
     public bool IsDialect(Type connectionType)
@@ -33,6 +35,11 @@ public abstract class AbstractTargetConnectionDialect : ITargetConnectionDialect
     public ISet<string> GetAllowedOnConnectionMethodNames()
     {
         throw new NotImplementedException("Will implement in Milestone 5, as feature is only relevant to Failover.");
+    }
+
+    public virtual string GetPluginCodesOrDefault(Dictionary<string, string> props)
+    {
+        return PropertyDefinition.Plugins.GetString(props) ?? DefaultPluginCode;
     }
 
     protected string PrepareConnectionString(IDialect dialect, HostSpec? hostSpec, Dictionary<string, string> props, AwsWrapperProperty hostProperty)

--- a/AwsWrapperDataProvider/Driver/TargetConnectionDialects/ITargetConnectionDialect.cs
+++ b/AwsWrapperDataProvider/Driver/TargetConnectionDialects/ITargetConnectionDialect.cs
@@ -50,4 +50,12 @@ public interface ITargetConnectionDialect
     /// </summary>
     /// <returns>Set of allowed method names.</returns>
     ISet<string> GetAllowedOnConnectionMethodNames();
+
+    /// <summary>
+    /// Prepares the plugin codes from the given props if specified.
+    /// Returns default plugin codes that are compatible with the dialect otherwise.
+    /// </summary>
+    /// <param name="props">Connection properties.</param>
+    /// <returns>A string of plugin codes.</returns>
+    string GetPluginCodesOrDefault(Dictionary<string, string> props);
 }

--- a/AwsWrapperDataProvider/Driver/Utils/PropertyDefinition.cs
+++ b/AwsWrapperDataProvider/Driver/Utils/PropertyDefinition.cs
@@ -48,7 +48,7 @@ public static class PropertyDefinition
 
     public static readonly AwsWrapperProperty Plugins = new(
         "Plugins",
-        "efm,failover",
+        null,
         "Comma separated list of connection plugin codes");
 
     public static readonly AwsWrapperProperty AutoSortPluginOrder = new(


### PR DESCRIPTION
### Summary

EFM plugin does not work with mysql therefore must be handled differently.

### Description

Adding new method to indicate whether a target connect dialect is mysql then updating plugin chain builder to either:
1. Not include EFM if no plugin code is provided.
2. Throw exception if EFM is used with mysql.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
