### PR TITLE
fix: workflow fix for MySQL project not existing

### DIFF
--- a/test/integration/host/src/test/java/integration/host/util/ContainerHelper.java
+++ b/test/integration/host/src/test/java/integration/host/util/ContainerHelper.java
@@ -104,11 +104,11 @@ public class ContainerHelper {
     // For Entity Framework tests
     if (task.endsWith("ef")) {
         exitCode = execInContainer(container, consumer,
-                "dotnet", "ef", "migrations", "add", "InitialCreate_" + System.currentTimeMillis(), "--project", "AwsWrapperDataProvider.EntityFrameworkCore.MySQL.Tests");
+                "dotnet", "ef", "migrations", "add", "InitialCreate_" + System.currentTimeMillis(), "--project", "AwsWrapperDataProvider.EntityFrameworkCore.MySqlConnector.Tests");
         assertEquals(0, exitCode, "Failed to generate Entity framework migration.");
 
         exitCode = execInContainer(container, consumer,
-                "dotnet", "ef", "database", "update", "--project", "AwsWrapperDataProvider.EntityFrameworkCore.MySQL.Tests");
+                "dotnet", "ef", "database", "update", "--project", "AwsWrapperDataProvider.EntityFrameworkCore.MySqlConnector.Tests");
         assertEquals(0, exitCode, "Failed to update database with migration");
     }
 


### PR DESCRIPTION
### Summary

Did not change all the MySQL references to MySqlConnector

### Description

In refactoring PR, did not change all references to MySQL to MySQlConnector and failing some workflows.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
