### PR TITLE
fix: error when plugin codes empty

### DIFF
--- a/AwsWrapperDataProvider.Dialect.MySqlConnector/MySqlConnectorDialect.cs
+++ b/AwsWrapperDataProvider.Dialect.MySqlConnector/MySqlConnectorDialect.cs
@@ -23,7 +23,7 @@ namespace AwsWrapperDataProvider.Dialect.MySqlConnector;
 
 public class MySqlConnectorDialect : AbstractTargetConnectionDialect
 {
-    private const string DefaultPluginCode = "initialConnection, failover";
+    private const string DefaultPluginCode = "initialConnection,failover";
 
     public override Type DriverConnectionType { get; } = typeof(MySqlConnection);
 

--- a/AwsWrapperDataProvider/Driver/Dialects/AuroraMySqlDialect.cs
+++ b/AwsWrapperDataProvider/Driver/Dialects/AuroraMySqlDialect.cs
@@ -64,7 +64,7 @@ public class AuroraMySqlDialect : MySqlDialect
     private HostListProviderSupplier GetHostListProviderSupplier()
     {
         return (props, hostListProviderService, pluginService) =>
-            PropertyDefinition.Plugins.GetString(props)!.Contains("failover") ?
+            (PropertyDefinition.Plugins.GetString(props) ?? DefaultPluginCodes).Contains("failover") ?
                 new MonitoringRdsHostListProvider(
                     props,
                     hostListProviderService,

--- a/AwsWrapperDataProvider/Driver/Dialects/AuroraPgDialect.cs
+++ b/AwsWrapperDataProvider/Driver/Dialects/AuroraPgDialect.cs
@@ -91,7 +91,7 @@ public class AuroraPgDialect : PgDialect
     private HostListProviderSupplier GetHostListProviderSupplier()
     {
         return (props, hostListProviderService, pluginService) =>
-            PropertyDefinition.Plugins.GetString(props)!.Contains("failover") ?
+            (PropertyDefinition.Plugins.GetString(props) ?? DefaultPluginCodes).Contains("failover") ?
                 new MonitoringRdsHostListProvider(
                     props,
                     hostListProviderService,

--- a/AwsWrapperDataProvider/Driver/Dialects/MySqlDialect.cs
+++ b/AwsWrapperDataProvider/Driver/Dialects/MySqlDialect.cs
@@ -25,6 +25,8 @@ public class MySqlDialect : IDialect
 {
     private static readonly ILogger<MySqlDialect> Logger = LoggerUtils.GetLogger<MySqlDialect>();
 
+    public static readonly string DefaultPluginCodes = "initialConnection,failover";
+
     public int DefaultPort { get; } = 3306;
 
     public string HostAliasQuery { get; } = "SELECT CONCAT(@@hostname, ':', @@port)";

--- a/AwsWrapperDataProvider/Driver/Dialects/PgDialect.cs
+++ b/AwsWrapperDataProvider/Driver/Dialects/PgDialect.cs
@@ -26,6 +26,8 @@ public class PgDialect : IDialect
 {
     private static readonly ILogger<PgDialect> Logger = LoggerUtils.GetLogger<PgDialect>();
 
+    public static readonly string DefaultPluginCodes = "initialConnection,efm,failover";
+
     public int DefaultPort { get; } = 5432;
 
     public string HostAliasQuery { get; } = "SELECT pg_catalog.CONCAT(pg_catalog.inet_server_addr(), ':', pg_catalog.inet_server_port())";

--- a/AwsWrapperDataProvider/Driver/Dialects/RdsMultiAzDbClusterMySqlDialect.cs
+++ b/AwsWrapperDataProvider/Driver/Dialects/RdsMultiAzDbClusterMySqlDialect.cs
@@ -93,7 +93,7 @@ public class RdsMultiAzDbClusterMySqlDialect : MySqlDialect
     private HostListProviderSupplier GetHostListProviderSupplier()
     {
         return (props, hostListProviderService, pluginService) =>
-            PropertyDefinition.Plugins.GetString(props)!.Contains("failover") ?
+            (PropertyDefinition.Plugins.GetString(props) ?? DefaultPluginCodes).Contains("failover") ?
                 new MonitoringRdsMultiAzHostListProvider(
                     props,
                     hostListProviderService,

--- a/AwsWrapperDataProvider/Driver/Dialects/RdsMultiAzDbClusterPgDialect.cs
+++ b/AwsWrapperDataProvider/Driver/Dialects/RdsMultiAzDbClusterPgDialect.cs
@@ -72,7 +72,7 @@ public class RdsMultiAzDbClusterPgDialect : PgDialect
     private HostListProviderSupplier GetHostListProviderSupplier()
     {
         return (props, hostListProviderService, pluginService) =>
-            PropertyDefinition.Plugins.GetString(props)!.Contains("failover") ?
+            (PropertyDefinition.Plugins.GetString(props) ?? DefaultPluginCodes).Contains("failover") ?
                 new MonitoringRdsMultiAzHostListProvider(
                     props,
                     hostListProviderService,


### PR DESCRIPTION
### Summary

Empty Plugin Codes throws error with dialects

### Description

Default to default plugin codes when empty.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
