### PR TITLE
bug: dotnet-ef install error

### DIFF
--- a/test/integration/host/src/test/java/integration/host/util/ContainerHelper.java
+++ b/test/integration/host/src/test/java/integration/host/util/ContainerHelper.java
@@ -201,7 +201,7 @@ public class ContainerHelper {
                 builder -> appendExtraCommandsToBuilder.apply(
                     builder
                         .from(testContainerImageName)
-                        .run("dotnet tool install --global dotnet-ef")
+                        .run("dotnet tool install --global dotnet-ef --version 9.0.10")
                         .env("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.dotnet/tools")
                         .run("mkdir", "app")
                         .workDir("/app")


### PR DESCRIPTION
### Summary

Pinned version for dotnet-ef install due to https://github.com/dotnet/efcore/issues/37128.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
