### PR TITLE
test: long pg integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,9 +2,6 @@ name: Integration Tests Default
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - test/long-pg-integration-tests
 
 permissions:
   id-token: write   # This is required for requesting the JWT
@@ -17,8 +14,8 @@ jobs:
     strategy: 
       fail-fast: false
       matrix:
-        dbEngine: ["pg"]
-        deployment: ["aurora"]
+        dbEngine: ["mysql", "pg"]
+        deployment: ["aurora", "multi-az-cluster", "multi-az-instance"]
     steps:
       - name: 'Clone repository'
         uses: actions/checkout@v4

--- a/test/integration/host/src/test/java/integration/host/util/ContainerHelper.java
+++ b/test/integration/host/src/test/java/integration/host/util/ContainerHelper.java
@@ -201,7 +201,7 @@ public class ContainerHelper {
                 builder -> appendExtraCommandsToBuilder.apply(
                     builder
                         .from(testContainerImageName)
-                        .run("dotnet tool install --global dotnet-ef --version 9.0.10")
+                        .run("dotnet tool install --global dotnet-ef")
                         .env("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.dotnet/tools")
                         .run("mkdir", "app")
                         .workDir("/app")


### PR DESCRIPTION
### Summary

Fix Aurora PG integration tests taking a long time to recover between tests.

### Description

Tests were taking a long time to recover because when it creates new connections to `GetAuroraInstanceIds` it was using a pooled connection. This occasionally results in end of stream error, causing the test to reboot the entire cluster: `Cluster test-pg-6jiiulncg0 is not healthy: Exception while reading from stream. Rebooting all instances and retrying...`

This change disables connection pooling in `GetAuroraInstanceIds`

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
