### PR TITLE
fix: replace volatile with interlocked

### DIFF
--- a/AwsWrapperDataProvider/Driver/Plugins/AuroraInitialConnectionStrategy/AuroraInitialConnectionStrategyPlugin.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/AuroraInitialConnectionStrategy/AuroraInitialConnectionStrategyPlugin.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Data;
 using System.Data.Common;
 using AwsWrapperDataProvider.Driver.Exceptions;
 using AwsWrapperDataProvider.Driver.HostInfo;

--- a/AwsWrapperDataProvider/Driver/Plugins/Efm/HostMonitorConnectionContext.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/Efm/HostMonitorConnectionContext.cs
@@ -23,12 +23,12 @@ public class HostMonitorConnectionContext
     private static readonly ILogger<HostMonitorConnectionContext> Logger = LoggerUtils.GetLogger<HostMonitorConnectionContext>();
     private readonly WeakReference<DbConnection?> connectionToAbort = new(null);
     private readonly object contextLock = new();
-    private volatile bool nodeUnhealthy = false;
+    private int nodeUnhealthy = 0;
 
     public bool NodeUnhealthy
     {
-        get => this.nodeUnhealthy;
-        set => this.nodeUnhealthy = value;
+        get => Volatile.Read(ref this.nodeUnhealthy) == 1;
+        set => Interlocked.Exchange(ref this.nodeUnhealthy, value ? 1 : 0);
     }
 
     public HostMonitorConnectionContext(DbConnection connectionToAbort)


### PR DESCRIPTION
### Summary
volatile is misused in shared counters
<!--- General summary / title -->

### Description
- Switched to Interlocked class to atomically set and read
<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
