### PR TITLE
chore: remove ip address at the end of integ workflows

### DIFF
--- a/.github/workflows/ef-test.yml
+++ b/.github/workflows/ef-test.yml
@@ -57,3 +57,12 @@ jobs:
           name: integration-report-default-${{ matrix.dbEngine }}
           path: ./test/integration/container/reports
           retention-days: 5
+      - name: Get Github Action IP
+        if: always()
+        id: ip
+        uses: haythem/public-ip@v1.3
+      - name: Remove Github Action IP
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -58,3 +58,11 @@ jobs:
           name: integration-report-default-${{ matrix.dbEngine }}
           path: ./test/integration/reports
           retention-days: 5
+      - name: Get Github Action IP
+        if: always()
+        id: ip
+        uses: haythem/public-ip@v1.3
+      - name: Remove Github Action IP
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/nhibernate-test.yml
+++ b/.github/workflows/nhibernate-test.yml
@@ -58,3 +58,11 @@ jobs:
           name: nhibernate-integration-report-${{ matrix.dbEngine }}-${{ matrix.deployment }}
           path: ./test/integration/container/reports
           retention-days: 5
+      - name: Get Github Action IP
+        if: always()
+        id: ip
+        uses: haythem/public-ip@v1.3
+      - name: Remove Github Action IP
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/nuget-release.yml
+++ b/.github/workflows/nuget-release.yml
@@ -33,3 +33,13 @@ jobs:
         run: |
           $nugetKey = aws secretsmanager get-secret-value --secret-id ${{ secrets.NUGET_SECRETS_ID }} --region ${{ secrets.AWS_NUGET_KEY_REGION }} --output text --query SecretString | ConvertFrom-Json
           dotnet nuget push .\packages\*.nupkg --source https://api.nuget.org/v3/index.json --api-key $nugetKey.Key
+
+      - name: Get Github Action IP
+        if: always()
+        id: ip
+        uses: haythem/public-ip@v1.3
+
+      - name: Remove Github Action IP
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/.github/workflows/rw-split-perf-test.yml
+++ b/.github/workflows/rw-split-perf-test.yml
@@ -52,7 +52,6 @@ jobs:
           PG_VERSION: "default"
           PERF_RESULTS_DIR: ${{ env.PERF_RESULTS_DIR }}
           LOG_LEVEL: None
-
       - name: Archive results
         if: always()
         uses: actions/upload-artifact@v4
@@ -61,3 +60,11 @@ jobs:
           path: ${{ env.PERF_RESULTS_DIR }}/**/*.xlsx
           retention-days: 5
           if-no-files-found: warn
+      - name: Get Github Action IP
+        if: always()
+        id: ip
+        uses: haythem/public-ip@v1.3
+      - name: Remove Github Action IP
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr ${{ steps.ip.outputs.ipv4 }}/32


### PR DESCRIPTION
### Summary

chore: remove ip address at the end of integ workflows. If the test framework fails or throw an exception, then the ip address will not be removed. This step ensures that it will be cleaned up regardless.

NOTE: this command should not fail as long as we have valid credentials AND the parameters in the aws ec2 are not malformed. 

```
<command>  aws ec2 revoke-security-group-ingress --group-name default --protocol all --port 0-65535 --cidr 96.249.182.174/32 # random Ip

< returns>
{
    "Return": true,
    "UnknownIpPermissions": [
        {
            "IpProtocol": "-1",
            "UserIdGroupPairs": [],
            "IpRanges": [
                {
                    "CidrIp": "96.249.182.174/32"
                }
            ],
            "Ipv6Ranges": [],
            "PrefixListIds": []
        }
    ],
    "RevokedSecurityGroupRules": []
}

<command> echo $?
0 
```

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
