### PR TITLE
fix: failing integration tests due to reboot and null writer for custom endpoint

### DIFF
--- a/AwsWrapperDataProvider.Tests/Container/Utils/AuroraTestUtils.cs
+++ b/AwsWrapperDataProvider.Tests/Container/Utils/AuroraTestUtils.cs
@@ -995,8 +995,12 @@ public class AuroraTestUtils
     {
         await this.WaitUntilClusterHasRightStateAsync(clusterId);
 
-        int remainingAttempts = 10;
-        while (--remainingAttempts > 0)
+        // This loop only needs to get the failover request accepted; waiting for failover to
+        // complete happens downstream. Aurora failover typically takes ~30s, during which the
+        // cluster reports "failing-over". A 60s deadline comfortably covers transient errors and
+        // the brief race where the cluster state flips after the pre-check above.
+        var deadline = DateTime.UtcNow + FromSeconds(60);
+        while (DateTime.UtcNow < deadline)
         {
             try
             {
@@ -1012,7 +1016,18 @@ public class AuroraTestUtils
             catch (Exception ex)
             {
                 Console.WriteLine($"{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss.fff} FailoverDBCluster request to {targetInstanceId} failed: {ex.Message}");
-                await Task.Delay(1000);
+
+                // A FailoverDBCluster call can return an error to the client even though the request
+                // was accepted server-side (e.g. a transient 500). Check the cluster's actual state:
+                // if it is already failing over, the failover is in progress, so stop retrying.
+                var status = (await this.GetDBClusterAsync(clusterId))?.Status;
+                if (string.Equals(status, "failing-over", StringComparison.OrdinalIgnoreCase))
+                {
+                    Console.WriteLine($"{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss.fff} Cluster {clusterId} is already failing over; failover triggered.");
+                    return;
+                }
+
+                await Task.Delay(FromSeconds(2));
             }
         }
 

--- a/AwsWrapperDataProvider.Tests/Container/Utils/TestEnvironment.cs
+++ b/AwsWrapperDataProvider.Tests/Container/Utils/TestEnvironment.cs
@@ -245,6 +245,19 @@ public class TestEnvironment
 
         foreach (var instanceId in instancesIDs)
         {
+            // The cluster reporting "available" does not guarantee that each individual
+            // instance is in a reboot-eligible state - an instance can still be "rebooting"
+            // (e.g. from a prior recovery round). RebootDBInstance only accepts instances in
+            // one of the states below, so wait for the instance before issuing the reboot to
+            // avoid a spurious "Can only reboot db instances with state in: ..." failure.
+            await auroraUtil.WaitUntilInstanceHasRightStateAsync(
+                instanceId,
+                "available",
+                "storage-optimization",
+                "storage-initialization",
+                "incompatible-credentials",
+                "incompatible-parameters");
+
             await auroraUtil.RebootInstanceAsync(instanceId);
         }
 

--- a/AwsWrapperDataProvider/Driver/Plugins/Failover/FailoverPlugin.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/Failover/FailoverPlugin.cs
@@ -405,7 +405,7 @@ public class FailoverPlugin : AbstractConnectionPlugin
     {
         var hosts = this.pluginService.GetHosts();
         Logger.LogDebug(LoggerUtils.LogTopology(hosts, $"All hosts: "));
-        var originalWriter = hosts.FirstOrDefault(h => h.Role == HostRole.Writer);
+        HostSpec? originalWriter = null;
         bool isOriginalWriterStillWriter = false;
 
         do
@@ -415,6 +415,19 @@ public class FailoverPlugin : AbstractConnectionPlugin
             hosts = this.pluginService.GetHosts();
             hosts.ToList().ForEach(hostSpec => this.pluginService.SetAvailability(hostSpec, HostAvailability.Available));
             var readerCandidates = hosts.Where(h => h.Role == HostRole.Reader).ToHashSet();
+
+            // Capture the original writer from the freshly refreshed topology. This must be done inside
+            // the loop because the host list can be empty before cluster topology is discovered — most
+            // notably with a custom endpoint, whose host list is filtered to its members and stays empty
+            // until the topology monitor populates it.
+            if (originalWriter == null)
+            {
+                originalWriter = hosts.FirstOrDefault(h => h.Role == HostRole.Writer);
+                if (originalWriter != null)
+                {
+                    isOriginalWriterStillWriter = false;
+                }
+            }
 
             // First, try all original readers
             var remainingReaders = new HashSet<HostSpec>(readerCandidates);


### PR DESCRIPTION

### Summary
Fix potential failing reboot due to instance state not ready to reboot and potential null writer in custom endpoint

<!--- General summary / title -->

<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
