### PR TITLE
fix: flakey read write splitting tests

### DIFF
--- a/AwsWrapperDataProvider.Tests/Driver/Plugins/ReadWriteSplitting/ReadWriteSplittingPluginTests.cs
+++ b/AwsWrapperDataProvider.Tests/Driver/Plugins/ReadWriteSplitting/ReadWriteSplittingPluginTests.cs
@@ -1,0 +1,234 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Data.Common;
+using AwsWrapperDataProvider.Driver;
+using AwsWrapperDataProvider.Driver.Dialects;
+using AwsWrapperDataProvider.Driver.HostInfo;
+using AwsWrapperDataProvider.Driver.HostListProviders;
+using AwsWrapperDataProvider.Driver.Plugins;
+using AwsWrapperDataProvider.Driver.Plugins.ReadWriteSplitting;
+using AwsWrapperDataProvider.Properties;
+using Moq;
+
+namespace AwsWrapperDataProvider.Tests.Driver.Plugins.ReadWriteSplitting;
+
+public class ReadWriteSplittingPluginTests
+{
+    private const int TestPort = 5432;
+
+    private readonly Mock<IPluginService> mockPluginService;
+    private readonly Mock<IHostListProviderService> mockHostListProviderService;
+    private readonly Mock<IDialect> mockDialect;
+    private readonly Mock<DbConnection> mockWriterConn;
+    private readonly Mock<DbConnection> mockReaderConn1;
+    private readonly Dictionary<string, string> props;
+
+    private readonly HostSpec writerHostSpec;
+    private readonly HostSpec readerHostSpec1;
+    private readonly HostSpec readerHostSpec2;
+    private readonly List<HostSpec> defaultHosts;
+    private readonly List<HostSpec> singleReaderTopology;
+
+    public ReadWriteSplittingPluginTests()
+    {
+        this.mockPluginService = new Mock<IPluginService>();
+        this.mockHostListProviderService = new Mock<IHostListProviderService>();
+        this.mockDialect = new Mock<IDialect>();
+        this.mockWriterConn = new Mock<DbConnection>();
+        this.mockReaderConn1 = new Mock<DbConnection>();
+        this.props = new Dictionary<string, string>();
+
+        this.writerHostSpec = new HostSpec("instance-0", TestPort, HostRole.Writer, HostAvailability.Available);
+        this.readerHostSpec1 = new HostSpec("instance-1", TestPort, HostRole.Reader, HostAvailability.Available);
+        this.readerHostSpec2 = new HostSpec("instance-2", TestPort, HostRole.Reader, HostAvailability.Available);
+
+        this.defaultHosts = [this.writerHostSpec, this.readerHostSpec1, this.readerHostSpec2];
+        this.singleReaderTopology = [this.writerHostSpec, this.readerHostSpec1];
+
+        this.MockDefaultBehavior();
+    }
+
+    private void MockDefaultBehavior()
+    {
+        // The current connection is an open writer connection (the read/write split starts from the writer).
+        this.mockWriterConn.Setup(x => x.State).Returns(System.Data.ConnectionState.Open);
+        this.mockReaderConn1.Setup(x => x.State).Returns(System.Data.ConnectionState.Open);
+
+        this.mockPluginService.Setup(x => x.CurrentConnection).Returns(this.mockWriterConn.Object);
+        this.mockPluginService.Setup(x => x.CurrentHostSpec).Returns(this.writerHostSpec);
+        this.mockPluginService.Setup(x => x.CurrentTransaction).Returns((DbTransaction?)null);
+        this.mockPluginService.Setup(x => x.AllHosts).Returns(this.defaultHosts);
+        this.mockPluginService.Setup(x => x.GetHosts()).Returns(this.defaultHosts);
+        this.mockPluginService.Setup(x => x.Dialect).Returns(this.mockDialect.Object);
+        this.mockPluginService.Setup(x => x.AcceptsStrategy(It.IsAny<string>())).Returns(true);
+        this.mockPluginService
+            .Setup(x => x.GetHostSpecByStrategy(It.IsAny<IList<HostSpec>>(), HostRole.Reader, It.IsAny<string>()))
+            .Returns(this.readerHostSpec1);
+        this.mockPluginService
+            .Setup(x => x.OpenConnection(this.readerHostSpec1, It.IsAny<Dictionary<string, string>>(), It.IsAny<IConnectionPlugin>(), It.IsAny<bool>()))
+            .ReturnsAsync(this.mockReaderConn1.Object);
+
+        // Refreshing the host list is a no-op in these tests.
+        this.mockPluginService.Setup(x => x.RefreshHostListAsync()).Returns(Task.CompletedTask);
+
+        // The dialect recognizes the command as a "set read only = true" statement so that Execute routes
+        // through SwitchConnectionIfRequired (the .NET equivalent of JDBC's switchConnectionIfRequired(true)).
+        this.mockDialect.Setup(x => x.DoesStatementSetReadOnly(It.IsAny<string>())).Returns((true, true));
+    }
+
+    private ReadWriteSplittingPlugin CreatePlugin()
+    {
+        var plugin = new ReadWriteSplittingPlugin(this.mockPluginService.Object, this.props);
+        plugin.InitHostProvider(
+            string.Empty,
+            this.props,
+            this.mockHostListProviderService.Object,
+            () => Task.CompletedTask);
+        return plugin;
+    }
+
+    /// <summary>
+    /// Drives the plugin the way the wrapper does: a SET READ ONLY command flows through Execute, which
+    /// invokes SwitchConnectionIfRequired(true).
+    /// </summary>
+    private Task InvokeSetReadOnlyTrue(ReadWriteSplittingPlugin plugin)
+    {
+        var mockCommand = new Mock<DbCommand>();
+        mockCommand.Setup(x => x.CommandText).Returns("SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY");
+
+        var methodFunc = new Mock<ADONetDelegate<object>>();
+        methodFunc.Setup(x => x.Invoke()).ReturnsAsync(new object());
+
+        return plugin.Execute(mockCommand.Object, "ExecuteNonQuery", methodFunc.Object);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task SetReadOnlyTrue_ReaderConnectionFailed_TriesEachReaderOnceThenFallsBack()
+    {
+        this.mockPluginService.Setup(x => x.AllHosts).Returns(this.singleReaderTopology);
+        this.mockPluginService.Setup(x => x.GetHosts()).Returns(this.singleReaderTopology);
+        this.mockPluginService
+            .Setup(x => x.OpenConnection(this.readerHostSpec1, It.IsAny<Dictionary<string, string>>(), It.IsAny<IConnectionPlugin>(), It.IsAny<bool>()))
+            .ThrowsAsync(new TestDbException());
+
+        // The selector returns the reader from the local candidate list until it is removed after the failed
+        // attempt, after which the selector reports no eligible reader (the .NET selectors throw for this).
+        this.mockPluginService
+            .Setup(x => x.GetHostSpecByStrategy(It.IsAny<IList<HostSpec>>(), HostRole.Reader, It.IsAny<string>()))
+            .Returns((IList<HostSpec> candidates, HostRole _, string _) =>
+                candidates.Contains(this.readerHostSpec1)
+                    ? this.readerHostSpec1
+                    : throw new InvalidOperationException(string.Format(Resources.Error_NoHostsMatching, HostRole.Reader)));
+
+        var plugin = this.CreatePlugin();
+
+        // The current writer connection is usable, so the failed reader switch falls back to it without throwing.
+        await this.InvokeSetReadOnlyTrue(plugin);
+
+        // The failed reader should be tried exactly once (it is removed from the local candidate list after the
+        // failure), and no global availability state should be changed.
+        this.mockPluginService.Verify(
+            x => x.OpenConnection(this.readerHostSpec1, It.IsAny<Dictionary<string, string>>(), It.IsAny<IConnectionPlugin>(), It.IsAny<bool>()),
+            Times.Once);
+        this.mockPluginService.Verify(
+            x => x.SetAvailability(It.IsAny<HostSpec>(), It.IsAny<HostAvailability>()),
+            Times.Never);
+
+        // The current writer connection is kept as a fallback (no switch to a reader).
+        this.mockPluginService.Verify(
+            x => x.SetCurrentConnection(It.IsAny<DbConnection>(), It.IsAny<HostSpec>()),
+            Times.Never);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task SetReadOnlyTrue_ReaderLoginFailed_RethrowsAndDoesNotChangeAvailability()
+    {
+        // Use the full topology and a selector that always returns reader1, so that absent the login
+        // showstopper the failed reader would be removed and re-selected, producing further attempts. The
+        // single-attempt assertion below is therefore meaningful.
+        this.mockPluginService
+            .Setup(x => x.OpenConnection(this.readerHostSpec1, It.IsAny<Dictionary<string, string>>(), It.IsAny<IConnectionPlugin>(), It.IsAny<bool>()))
+            .ThrowsAsync(new TestDbException());
+
+        // The failure is a login/authentication failure, which does not indicate the host is unreachable.
+        this.mockPluginService.Setup(x => x.IsLoginException(It.IsAny<Exception>())).Returns(true);
+
+        var plugin = this.CreatePlugin();
+
+        // A login failure is a showstopper: OpenNewReaderConnection rethrows the exception immediately instead
+        // of removing the reader and retrying, so only a single connection attempt is made. The outer switch
+        // then falls back to the usable writer connection (no exception surfaces here).
+        await this.InvokeSetReadOnlyTrue(plugin);
+
+        // Only a single connection attempt is made before rethrowing. Without the login-exception showstopper,
+        // the reader would be removed and re-selected, producing a second attempt.
+        this.mockPluginService.Verify(
+            x => x.OpenConnection(this.readerHostSpec1, It.IsAny<Dictionary<string, string>>(), It.IsAny<IConnectionPlugin>(), It.IsAny<bool>()),
+            Times.Once);
+
+        // No global availability state should be changed.
+        this.mockPluginService.Verify(
+            x => x.SetAvailability(It.IsAny<HostSpec>(), It.IsAny<HostAvailability>()),
+            Times.Never);
+
+        // No switch to a reader connection occurred.
+        this.mockPluginService.Verify(
+            x => x.SetCurrentConnection(It.IsAny<DbConnection>(), It.IsAny<HostSpec>()),
+            Times.Never);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task SetReadOnlyTrue_NoEligibleReader_FallsBackToWriter()
+    {
+        this.mockPluginService.Setup(x => x.AllHosts).Returns(this.singleReaderTopology);
+        this.mockPluginService.Setup(x => x.GetHosts()).Returns(this.singleReaderTopology);
+
+        // No eligible reader is available: the selector reports it (the .NET selectors throw in this case).
+        this.mockPluginService
+            .Setup(x => x.GetHostSpecByStrategy(It.IsAny<IList<HostSpec>>(), HostRole.Reader, It.IsAny<string>()))
+            .Throws(() => new InvalidOperationException(string.Format(Resources.Error_NoHostsMatching, HostRole.Reader)));
+
+        var plugin = this.CreatePlugin();
+
+        // With no eligible reader and a usable writer connection, the switch falls back to the writer.
+        await this.InvokeSetReadOnlyTrue(plugin);
+
+        // No connection attempt should be made when there is no eligible reader.
+        this.mockPluginService.Verify(
+            x => x.OpenConnection(this.readerHostSpec1, It.IsAny<Dictionary<string, string>>(), It.IsAny<IConnectionPlugin>(), It.IsAny<bool>()),
+            Times.Never);
+        this.mockPluginService.Verify(
+            x => x.SetAvailability(It.IsAny<HostSpec>(), It.IsAny<HostAvailability>()),
+            Times.Never);
+        this.mockPluginService.Verify(
+            x => x.SetCurrentConnection(It.IsAny<DbConnection>(), It.IsAny<HostSpec>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Minimal concrete <see cref="DbException"/> for simulating a non-login reader connection failure.
+    /// (<see cref="DbException"/> is abstract-constructible but we want an explicit, unambiguous type here.)
+    /// </summary>
+    private sealed class TestDbException : DbException
+    {
+        public TestDbException()
+            : base("Simulated reader connection failure.")
+        {
+        }
+    }
+}

--- a/AwsWrapperDataProvider.Tests/Driver/Plugins/ReadWriteSplitting/ReadWriteSplittingPluginTests.cs
+++ b/AwsWrapperDataProvider.Tests/Driver/Plugins/ReadWriteSplitting/ReadWriteSplittingPluginTests.cs
@@ -84,7 +84,7 @@ public class ReadWriteSplittingPluginTests
         this.mockPluginService.Setup(x => x.RefreshHostListAsync()).Returns(Task.CompletedTask);
 
         // The dialect recognizes the command as a "set read only = true" statement so that Execute routes
-        // through SwitchConnectionIfRequired (the .NET equivalent of JDBC's switchConnectionIfRequired(true)).
+        // through SwitchConnectionIfRequired.
         this.mockDialect.Setup(x => x.DoesStatementSetReadOnly(It.IsAny<string>())).Returns((true, true));
     }
 

--- a/AwsWrapperDataProvider.Tests/ReadWriteSplittingTests.cs
+++ b/AwsWrapperDataProvider.Tests/ReadWriteSplittingTests.cs
@@ -592,4 +592,71 @@ public class ReadWriteSplittingTests : IntegrationTestBase
 
         await ProxyHelper.EnableAllConnectivityAsync();
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    [Trait("Category", "Integration")]
+    [Trait("Database", "mysql")]
+    [Trait("Database", "pg")]
+    [Trait("Engine", "aurora")]
+    public async Task ConnectToProxyWriter_SwitchToReadOnly_OneReaderDown_FallsBackToWriter(bool async)
+    {
+        // Reproduces https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1324 (ported from PR #1966).
+        // In a 2-node cluster (1 writer, 1 reader), when the single reader becomes unreachable, SetReadOnly(true)
+        // should fall back to the writer instead of getting stuck retrying the unreachable reader. Once the reader
+        // becomes reachable again, SetReadOnly(true) should use it without any availability cache reset, since the
+        // plugin tracks failed readers only locally per call and never marks a host Unavailable globally.
+        Assert.SkipWhen(NumberOfInstances != 2, "Skipped due to test requiring number of database instances = 2.");
+        var proxyDatabaseInfo = ProxyDatabaseInfo ?? throw new InvalidOperationException("Proxy database info must be configured for read/write splitting tests.");
+        var proxyWriter = proxyDatabaseInfo.Instances.First();
+        var connectionString = ConnectionStringHelper.GetUrl(
+            Engine,
+            proxyWriter.Host,
+            proxyWriter.Port,
+            Username,
+            Password,
+            DefaultDbName,
+            3,
+            10,
+            "readWriteSplitting");
+        connectionString += $"; ClusterInstanceHostPattern=?.{proxyDatabaseInfo.InstanceEndpointSuffix}:{proxyDatabaseInfo.InstanceEndpointPort}";
+
+        using AwsWrapperConnection connection = AuroraUtils.CreateAwsWrapperConnection(Engine, connectionString);
+        await AuroraUtils.OpenDbConnection(connection, async);
+        Assert.Equal(ConnectionState.Open, connection.State);
+
+        var writerConnectionId = await AuroraUtils.QueryInstanceId(connection, async);
+
+        // Confirm the reader is reachable while connectivity is up.
+        await AuroraUtils.SetReadOnly(connection, Engine, true, async);
+        var readerConnectionId = await AuroraUtils.QueryInstanceId(connection, async);
+        Assert.NotEqual(writerConnectionId, readerConnectionId);
+
+        await AuroraUtils.SetReadOnly(connection, Engine, false, async);
+        Assert.Equal(writerConnectionId, await AuroraUtils.QueryInstanceId(connection, async));
+
+        // Disable connectivity to the single reader instance (and the read-only cluster endpoint that routes to it).
+        await ProxyHelper.DisableConnectivityAsync(proxyDatabaseInfo.ClusterReadOnlyEndpoint);
+        await ProxyHelper.DisableConnectivityAsync(readerConnectionId!);
+
+        // SetReadOnly(true) must not get stuck and must fall back to the writer.
+        await AuroraUtils.SetReadOnly(connection, Engine, true, async);
+        Assert.Equal(writerConnectionId, await AuroraUtils.QueryInstanceId(connection, async));
+
+        // A subsequent SetReadOnly(true) should still fall back to the writer without throwing.
+        await AuroraUtils.SetReadOnly(connection, Engine, false, async);
+        Assert.Equal(writerConnectionId, await AuroraUtils.QueryInstanceId(connection, async));
+        await AuroraUtils.SetReadOnly(connection, Engine, true, async);
+        Assert.Equal(writerConnectionId, await AuroraUtils.QueryInstanceId(connection, async));
+
+        // Restore connectivity. The reader should be usable again on the next request without any availability
+        // cache reset, since the plugin does not mark hosts Unavailable globally.
+        await ProxyHelper.EnableAllConnectivityAsync();
+
+        await AuroraUtils.SetReadOnly(connection, Engine, false, async);
+        Assert.Equal(writerConnectionId, await AuroraUtils.QueryInstanceId(connection, async));
+        await AuroraUtils.SetReadOnly(connection, Engine, true, async);
+        Assert.Equal(readerConnectionId, await AuroraUtils.QueryInstanceId(connection, async));
+    }
 }

--- a/AwsWrapperDataProvider.Tests/ReadWriteSplittingTests.cs
+++ b/AwsWrapperDataProvider.Tests/ReadWriteSplittingTests.cs
@@ -602,7 +602,6 @@ public class ReadWriteSplittingTests : IntegrationTestBase
     [Trait("Engine", "aurora")]
     public async Task ConnectToProxyWriter_SwitchToReadOnly_OneReaderDown_FallsBackToWriter(bool async)
     {
-        // Reproduces https://github.com/aws/aws-advanced-jdbc-wrapper/issues/1324 (ported from PR #1966).
         // In a 2-node cluster (1 writer, 1 reader), when the single reader becomes unreachable, SetReadOnly(true)
         // should fall back to the writer instead of getting stuck retrying the unreachable reader. Once the reader
         // becomes reachable again, SetReadOnly(true) should use it without any availability cache reset, since the

--- a/AwsWrapperDataProvider/Driver/HostListProviders/Monitoring/ClusterTopologyMonitor.cs
+++ b/AwsWrapperDataProvider/Driver/HostListProviders/Monitoring/ClusterTopologyMonitor.cs
@@ -618,7 +618,7 @@ public class ClusterTopologyMonitor : IClusterTopologyMonitor
     /// monitor-observed availability transient and recomputed on every publish, so a momentary probe failure
     /// never overrides a fresh topology on an unrelated connection.
     /// </summary>
-    protected void UpdateHostsAvailability(IList<HostSpec>? hosts)
+    protected void UpdateReaderHostsAvailability(IList<HostSpec>? hosts)
     {
         if (hosts == null || hosts.Count == 0)
         {
@@ -718,7 +718,7 @@ public class ClusterTopologyMonitor : IClusterTopologyMonitor
             Logger.LogDebug(
                 Resources.ClusterTopologyMonitor_MatchingReaderTopologies,
                 (long)elapsed.TotalMilliseconds);
-            this.UpdateHostsAvailability(readerTopologyFirstEntry);
+            this.UpdateReaderHostsAvailability(readerTopologyFirstEntry);
             this.UpdateTopologyCache(readerTopologyFirstEntry);
         }
     }
@@ -933,7 +933,7 @@ public class ClusterTopologyMonitor : IClusterTopologyMonitor
 
                 if (this.writerChanged)
                 {
-                    monitor.UpdateHostsAvailability(hosts);
+                    monitor.UpdateReaderHostsAvailability(hosts);
                     monitor.UpdateTopologyCache(hosts);
                     return;
                 }
@@ -947,7 +947,7 @@ public class ClusterTopologyMonitor : IClusterTopologyMonitor
                         latestWriterHostSpec.Host));
 
                     this.writerChanged = true;
-                    monitor.UpdateHostsAvailability(hosts);
+                    monitor.UpdateReaderHostsAvailability(hosts);
                     monitor.UpdateTopologyCache(hosts);
                 }
             }

--- a/AwsWrapperDataProvider/Driver/HostListProviders/Monitoring/ClusterTopologyMonitor.cs
+++ b/AwsWrapperDataProvider/Driver/HostListProviders/Monitoring/ClusterTopologyMonitor.cs
@@ -616,7 +616,7 @@ public class ClusterTopologyMonitor : IClusterTopologyMonitor
     /// availability cache. A reader is Available when a node monitor currently tracks a topology for it
     /// (<see cref="readerTopologiesById"/> contains its host id); otherwise it is Unavailable. This keeps
     /// monitor-observed availability transient and recomputed on every publish, so a momentary probe failure
-    /// never overrides a fresh topology on an unrelated connection (see JDBC ClusterTopologyMonitorImpl.updateHostsAvailability).
+    /// never overrides a fresh topology on an unrelated connection.
     /// </summary>
     protected void UpdateHostsAvailability(IList<HostSpec>? hosts)
     {

--- a/AwsWrapperDataProvider/Driver/HostListProviders/Monitoring/ClusterTopologyMonitor.cs
+++ b/AwsWrapperDataProvider/Driver/HostListProviders/Monitoring/ClusterTopologyMonitor.cs
@@ -611,6 +611,28 @@ public class ClusterTopologyMonitor : IClusterTopologyMonitor
         }
     }
 
+    /// <summary>
+    /// Derives each host's availability from the node monitors' own bookkeeping rather than from the shared
+    /// availability cache. A reader is Available when a node monitor currently tracks a topology for it
+    /// (<see cref="readerTopologiesById"/> contains its host id); otherwise it is Unavailable. This keeps
+    /// monitor-observed availability transient and recomputed on every publish, so a momentary probe failure
+    /// never overrides a fresh topology on an unrelated connection (see JDBC ClusterTopologyMonitorImpl.updateHostsAvailability).
+    /// </summary>
+    protected void UpdateHostsAvailability(IList<HostSpec>? hosts)
+    {
+        if (hosts == null || hosts.Count == 0)
+        {
+            return;
+        }
+
+        foreach (HostSpec host in hosts)
+        {
+            host.Availability = host.HostId != null && this.readerTopologiesById.ContainsKey(host.HostId)
+                ? HostAvailability.Available
+                : HostAvailability.Unavailable;
+        }
+    }
+
     protected void UpdateTopologyCache(IList<HostSpec> hosts)
     {
         lock (this.topologyUpdatedLock)
@@ -696,6 +718,7 @@ public class ClusterTopologyMonitor : IClusterTopologyMonitor
             Logger.LogDebug(
                 Resources.ClusterTopologyMonitor_MatchingReaderTopologies,
                 (long)elapsed.TotalMilliseconds);
+            this.UpdateHostsAvailability(readerTopologyFirstEntry);
             this.UpdateTopologyCache(readerTopologyFirstEntry);
         }
     }
@@ -787,11 +810,9 @@ public class ClusterTopologyMonitor : IClusterTopologyMonitor
                         try
                         {
                             connection = await monitor.pluginService.ForceOpenConnection(hostSpec, monitor.properties, null, true);
-                            monitor.pluginService.SetAvailability(hostSpec, HostAvailability.Available);
                         }
                         catch (Exception ex) when (ex is DbException or EndOfStreamException)
                         {
-                            monitor.pluginService.SetAvailability(hostSpec, HostAvailability.Unavailable);
                             await monitor.DisposeConnectionAsync(connection);
                             connection = null;
                             monitor.completedOneCycle[hostSpec.HostId!] = true;
@@ -912,6 +933,7 @@ public class ClusterTopologyMonitor : IClusterTopologyMonitor
 
                 if (this.writerChanged)
                 {
+                    monitor.UpdateHostsAvailability(hosts);
                     monitor.UpdateTopologyCache(hosts);
                     return;
                 }
@@ -925,6 +947,7 @@ public class ClusterTopologyMonitor : IClusterTopologyMonitor
                         latestWriterHostSpec.Host));
 
                     this.writerChanged = true;
+                    monitor.UpdateHostsAvailability(hosts);
                     monitor.UpdateTopologyCache(hosts);
                 }
             }

--- a/AwsWrapperDataProvider/Driver/PluginService.cs
+++ b/AwsWrapperDataProvider/Driver/PluginService.cs
@@ -270,13 +270,6 @@ public class PluginService : IPluginService, IHostListProviderService
             host.Availability = availability;
             HostAvailabilityExpiringCache.Set(host.GetHostAndPort(), availability, DefaultHostAvailabilityCacheExpiration);
 
-            // Also store by HostId so availability can be restored when new HostSpec objects are created
-            // during topology refresh (e.g., for custom endpoint restrictions set before topology is populated)
-            if (!string.IsNullOrEmpty(host.HostId))
-            {
-                HostAvailabilityExpiringCache.Set(host.HostId, availability, DefaultHostAvailabilityCacheExpiration);
-            }
-
             if (currentAvailability != availability)
             {
                 Logger.LogTrace(Resources.PluginService_SetAvailability_HostAvailabilityChanged, host, currentAvailability, availability);
@@ -428,15 +421,9 @@ public class PluginService : IPluginService, IHostListProviderService
     {
         foreach (HostSpec host in hosts)
         {
-            // First try to restore from cache by host:port (for existing hosts)
+            // Restore availability from the cache by host:port only (matching JDBC's host.getUrl() keying).
+            // See SetAvailability for why we do not fall back to a HostId-keyed lookup.
             HostAvailabilityExpiringCache.TryGetValue(host.GetHostAndPort(), out HostAvailability? availability);
-
-            // If not found and host has a HostId, try to restore by HostId (for custom endpoint restrictions
-            // that were set before the topology refresh created these HostSpec objects)
-            if (!availability.HasValue && !string.IsNullOrEmpty(host.HostId))
-            {
-                HostAvailabilityExpiringCache.TryGetValue(host.HostId, out availability);
-            }
 
             if (availability.HasValue)
             {

--- a/AwsWrapperDataProvider/Driver/PluginService.cs
+++ b/AwsWrapperDataProvider/Driver/PluginService.cs
@@ -421,8 +421,6 @@ public class PluginService : IPluginService, IHostListProviderService
     {
         foreach (HostSpec host in hosts)
         {
-            // Restore availability from the cache by host:port only (matching JDBC's host.getUrl() keying).
-            // See SetAvailability for why we do not fall back to a HostId-keyed lookup.
             HostAvailabilityExpiringCache.TryGetValue(host.GetHostAndPort(), out HostAvailability? availability);
 
             if (availability.HasValue)

--- a/AwsWrapperDataProvider/Driver/Plugins/ReadWriteSplitting/ReadWriteSplittingPlugin.cs
+++ b/AwsWrapperDataProvider/Driver/Plugins/ReadWriteSplitting/ReadWriteSplittingPlugin.cs
@@ -273,11 +273,32 @@ public class ReadWriteSplittingPlugin : AbstractConnectionPlugin
     {
         DbConnection? connection = null;
         HostSpec? readerHost = null;
-        var hostCandidates = this.GetReaderHostCandidates();
-        int attempts = hostCandidates.Count * 2;
-        for (int i = 0; i < attempts; i++)
+
+        // Work on a local, mutable copy of the candidate hosts. When a connection attempt to a reader
+        // fails (for a non-login reason), the host is removed from this local list so it is not retried
+        // within this call. This is a local, per-call view of host availability and intentionally has
+        // no global side effects (it does not mark the host Unavailable in the shared availability
+        // cache), so a host that recovers is immediately eligible again on the next request.
+        var hostCandidates = this.GetReaderHostCandidates().ToList();
+
+        // Bound the number of attempts by the initial candidate count so a host selector that keeps
+        // returning the same host can never cause an infinite loop.
+        int maxAttempts = hostCandidates.Count;
+        for (int i = 0; i < maxAttempts && hostCandidates.Count > 0; i++)
         {
-            HostSpec hostSpec = this.pluginService.GetHostSpecByStrategy(hostCandidates.ToList(), HostRole.Reader, this.readerHostSelectorStrategy);
+            HostSpec hostSpec;
+            try
+            {
+                hostSpec = this.pluginService.GetHostSpecByStrategy(hostCandidates, HostRole.Reader, this.readerHostSelectorStrategy);
+            }
+            catch (InvalidOperationException)
+            {
+                // No eligible reader is left (the selector found no available reader among the remaining
+                // candidates). Stop retrying and fall back to the writer instead of continuing to spend the
+                // connect timeout on hosts that are already known to be unreachable.
+                break;
+            }
+
             try
             {
                 connection = await this.pluginService.OpenConnection(hostSpec, this.props, this, true);
@@ -286,6 +307,16 @@ public class ReadWriteSplittingPlugin : AbstractConnectionPlugin
             }
             catch (DbException ex)
             {
+                // A login/authentication failure (e.g. wrong credentials, expired IAM token) is a
+                // showstopper: retrying other readers won't help, so rethrow immediately.
+                if (this.pluginService.IsLoginException(ex))
+                {
+                    throw;
+                }
+
+                // Remove the failed reader from the local candidate list so it is not retried again during
+                // this call, then continue trying the remaining readers.
+                hostCandidates.Remove(hostSpec);
                 Logger.LogWarning(ex, string.Format(Resources.ReadWriteSplittingPlugin_FailedToConnectToReader, hostSpec));
             }
         }


### PR DESCRIPTION
### Summary
 Fix read/write splitting readers being wrongly marked unavailable, causing SetReadOnly(true) to fail with `No hosts found matching role: Reader.`
<!--- General summary / title -->

### Description
  - ClusterTopologyMonitor: stop writing host availability to the shared cache from background probes. Availability is now derived on the published topology from the monitor's own readerTopologiesById.
  - ReadWriteSplittingPlugin.OpenNewReaderConnection: work on a local per-call candidate copy, remove a failed reader locally, bound retries, rethrow login exceptions, and fall back to the writer when no reader is eligible
  - PluginService: key the availability cache by host:port only
<!--- Details of what you changed -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
