### PR TITLE
fix: flakey tests due to stale rds control plane results

### DIFF
--- a/AwsWrapperDataProvider.EntityFrameworkCore.Tests/AuroraConnectionTrackerConnectivityTests.cs
+++ b/AwsWrapperDataProvider.EntityFrameworkCore.Tests/AuroraConnectionTrackerConnectivityTests.cs
@@ -126,23 +126,12 @@ public class AuroraConnectionTrackerConnectivityTests : EFIntegrationTestBase
             await Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
             var clusterId = TestEnvironment.Env.Info.RdsDbName!;
-            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId);
+            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId, id => id != currentWriter, TimeSpan.FromMinutes(5));
 
-            if (currentWriter == newWriterId)
+            this.Logger.WriteLine($"Cluster failed over to instance {newWriterId}.");
+            foreach (var ctx in idleContexts)
             {
-                this.Logger.WriteLine($"Writer did not change, still {newWriterId}.");
-                foreach (var ctx in idleContexts)
-                {
-                    Assert.Equal(ConnectionState.Open, ctx.Database.GetDbConnection().State);
-                }
-            }
-            else
-            {
-                this.Logger.WriteLine($"Cluster failed over to instance {newWriterId}.");
-                foreach (var ctx in idleContexts)
-                {
-                    Assert.Equal(ConnectionState.Closed, ctx.Database.GetDbConnection().State);
-                }
+                Assert.Equal(ConnectionState.Closed, ctx.Database.GetDbConnection().State);
             }
 
             // Verify all data committed before the crash is still present.
@@ -245,23 +234,12 @@ public class AuroraConnectionTrackerConnectivityTests : EFIntegrationTestBase
             await Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
             var clusterId = TestEnvironment.Env.Info.RdsDbName!;
-            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId);
+            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId, id => id != currentWriter, TimeSpan.FromMinutes(5));
 
-            if (currentWriter == newWriterId)
+            this.Logger.WriteLine($"Cluster failed over to instance {newWriterId}.");
+            foreach (var ctx in idleContexts)
             {
-                this.Logger.WriteLine($"Writer did not change, still {newWriterId}.");
-                foreach (var ctx in idleContexts)
-                {
-                    Assert.Equal(ConnectionState.Open, ctx.Database.GetDbConnection().State);
-                }
-            }
-            else
-            {
-                this.Logger.WriteLine($"Cluster failed over to instance {newWriterId}.");
-                foreach (var ctx in idleContexts)
-                {
-                    Assert.Equal(ConnectionState.Closed, ctx.Database.GetDbConnection().State);
-                }
+                Assert.Equal(ConnectionState.Closed, ctx.Database.GetDbConnection().State);
             }
 
             // Verify all data committed before the crash is still present.
@@ -352,8 +330,7 @@ public class AuroraConnectionTrackerConnectivityTests : EFIntegrationTestBase
             await Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
             var clusterId = TestEnvironment.Env.Info.RdsDbName!;
-            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId);
-            Assert.SkipWhen(currentWriter == newWriterId, "Writer did not change after failover; cannot verify recovery.");
+            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId, id => id != currentWriter, TimeSpan.FromMinutes(5));
 
             this.Logger.WriteLine($"Cluster failed over to instance {newWriterId}.");
 
@@ -456,8 +433,7 @@ public class AuroraConnectionTrackerConnectivityTests : EFIntegrationTestBase
             await Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
             var clusterId = TestEnvironment.Env.Info.RdsDbName!;
-            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId);
-            Assert.SkipWhen(currentWriter == newWriterId, "Writer did not change after failover; cannot verify recovery.");
+            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId, id => id != currentWriter, TimeSpan.FromMinutes(5));
 
             this.Logger.WriteLine($"Cluster failed over to instance {newWriterId}.");
 

--- a/AwsWrapperDataProvider.NHibernate.Tests/AuroraConnectionTrackerConnectivityTests.cs
+++ b/AwsWrapperDataProvider.NHibernate.Tests/AuroraConnectionTrackerConnectivityTests.cs
@@ -138,8 +138,7 @@ public class AuroraConnectionTrackerConnectivityTests : NHibernateTestBase
             await Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
             var clusterId = TestEnvironment.Env.Info.RdsDbName!;
-            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId);
-            Assert.SkipWhen(currentWriter == newWriterId, "Writer did not change after failover; cannot verify tracker invalidation.");
+            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId, id => id != currentWriter, TimeSpan.FromMinutes(5));
 
             this.logger.WriteLine($"Cluster failed over from {currentWriter} to {newWriterId}.");
 
@@ -251,8 +250,7 @@ public class AuroraConnectionTrackerConnectivityTests : NHibernateTestBase
             await Task.Delay(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
             var clusterId = TestEnvironment.Env.Info.RdsDbName!;
-            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId);
-            Assert.SkipWhen(currentWriter == newWriterId, "Writer did not change after failover; cannot verify recovery.");
+            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId, id => id != currentWriter, TimeSpan.FromMinutes(5));
 
             this.logger.WriteLine($"Cluster failed over from {currentWriter} to {newWriterId}.");
 

--- a/AwsWrapperDataProvider.Tests/FailoverConnectivityTests.cs
+++ b/AwsWrapperDataProvider.Tests/FailoverConnectivityTests.cs
@@ -461,22 +461,15 @@ public class FailoverConnectivityTests : IntegrationTestBase
 
             // Query the RDS API to determine the current writer.
             var clusterId = TestEnvironment.Env.Info.RdsDbName!;
-            var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId);
 
-            if (currentWriter == newWriterId)
+            if (Deployment == DatabaseEngineDeployment.AURORA)
             {
-                this.logger.WriteLine($"Writer did not change, still {newWriterId}.");
-
-                // Writer didn't change — idle connections should still be open.
-                foreach (var idleConn in idleConnections)
-                {
-                    Assert.Equal(
-                        ConnectionState.Open,
-                        idleConn.State);
-                }
-            }
-            else
-            {
+                // On Aurora, CrashInstance performs a confirmed failover, so the writer changed.
+                // DescribeDBClusters is eventually consistent and can briefly regress to the
+                // pre-failover writer, so poll until the API catches up rather than trusting a
+                // single stale read.
+                var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(
+                    clusterId, id => id != currentWriter, TimeSpan.FromMinutes(5));
                 this.logger.WriteLine($"Cluster failed over to instance {newWriterId}.");
 
                 // Writer changed — all idle connections should be closed.
@@ -485,6 +478,37 @@ public class FailoverConnectivityTests : IntegrationTestBase
                     Assert.Equal(
                         ConnectionState.Closed,
                         idleConn.State);
+                }
+            }
+            else
+            {
+                // On RDS_MULTI_AZ_CLUSTER, CrashInstance only induces a transient network blip and
+                // the writer may or may not change, so the assertion depends on the actual writer.
+                var newWriterId = await AuroraUtils.GetDBClusterWriterInstanceIdAsync(clusterId);
+
+                if (currentWriter == newWriterId)
+                {
+                    this.logger.WriteLine($"Writer did not change, still {newWriterId}.");
+
+                    // Writer didn't change — idle connections should still be open.
+                    foreach (var idleConn in idleConnections)
+                    {
+                        Assert.Equal(
+                            ConnectionState.Open,
+                            idleConn.State);
+                    }
+                }
+                else
+                {
+                    this.logger.WriteLine($"Cluster failed over to instance {newWriterId}.");
+
+                    // Writer changed — all idle connections should be closed.
+                    foreach (var idleConn in idleConnections)
+                    {
+                        Assert.Equal(
+                            ConnectionState.Closed,
+                            idleConn.State);
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Summary
 Fix flaky idle-connection failover tests caused by stale RDS `DescribeDBClusters` reads
<!--- General summary / title -->

### Description

<!--- Details of what you changed -->
  - Use the retrying `GetDBClusterWriterInstanceIdAsync` overload to poll, and drop the "writer did not change" branches
### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
